### PR TITLE
Allow Ponder to be used as a subproject with add_subdirectory()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,11 @@ cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
 # set project's name
 project(Ponder)
 
-set(PONDER_SOURCE_DIR ${PROJECT_SOURCE_DIR})
+set(PONDER_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 # include project configuration
-include(${CMAKE_SOURCE_DIR}/cmake/Config.cmake)
-include(${CMAKE_SOURCE_DIR}/cmake/PackageFilename.cmake)
+include(${PONDER_SOURCE_DIR}/cmake/Config.cmake)
+include(${PONDER_SOURCE_DIR}/cmake/PackageFilename.cmake)
 
 # all source files
 set(SRC_HEADERS
@@ -177,8 +177,8 @@ include_directories(
 
 # generate version.hpp
 message("Generate version.hpp")
-configure_file(${CMAKE_SOURCE_DIR}/cmake/version.in
-               ${CMAKE_SOURCE_DIR}/include/ponder/version.hpp @ONLY)
+configure_file(${PONDER_SOURCE_DIR}/cmake/version.in
+               ${PONDER_SOURCE_DIR}/include/ponder/version.hpp @ONLY)
 
 # instruct CMake to build a shared library from all of the source files
 add_library(ponder ${PONDER_SRCS})

--- a/cmake/Config.cmake
+++ b/cmake/Config.cmake
@@ -42,5 +42,5 @@ elseif(UNIX)
 endif()
 
 # setup MacOSX build environment if necessary
-include(${CMAKE_SOURCE_DIR}/cmake/MacOSX.cmake)
+include(${PONDER_SOURCE_DIR}/cmake/MacOSX.cmake)
 

--- a/cmake/Packaging.cmake
+++ b/cmake/Packaging.cmake
@@ -77,7 +77,7 @@ set(CPACK_RESOURCE_FILE_README ${PONDER_SOURCE_DIR}/README.md)
 set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY Ponder)
 
 # Package filename setup
-include(${CMAKE_SOURCE_DIR}/cmake/PackageFilename.cmake)
+include(${PONDER_SOURCE_DIR}/cmake/PackageFilename.cmake)
 
 # set package file name
 string(TOLOWER ${CPACK_PACKAGE_NAME} LOWER_PACKAGE_NAME)


### PR DESCRIPTION
Ponder currently fails when used as a subproject, as it does not fully use a relative source directory.
It looks like work was started on this, via the `PONDER_SOURCE_DIR` variable, but this variable was not used consistently nor set to the correct value by default.

This PR expands usage of `PONDER_SOURCE_DIR`, allowing usage of Ponder as a subproject.