### PR TITLE
Fix __STRICT_ANSI__ related compile error (missing strcmpcase) on MinGW using C++11

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -29,6 +29,12 @@
 
 #include <ponder/detail/util.hpp>
 
+#if defined(__GNUWIN32__) and __cplusplus >= 201103L
+    // MinGW support using C++11 defines __STRICT_ANSI__ which removes strcasecmp
+    // used below. As a fix, undefine __STRICT_ANSI__ before including strings.h.
+#undef __STRICT_ANSI__
+#endif
+
 #ifdef _MSC_VER
 #   include <string.h>
 #else
@@ -54,7 +60,7 @@ static inline int stricmp(const char* a, const char* b)
 }
 
 // parse string
-    
+
 template <typename T>
 static bool parse_integer(const String& from, T& to)
 {
@@ -135,7 +141,7 @@ bool conv(const String& from, unsigned long long& to)
     }
     return true;
 }
-    
+
 bool conv(const String& from, bool& to)
 {
     const char *s = from.c_str();
@@ -184,7 +190,7 @@ static const char* c_typeNames[] =
     "array",    // ValueKind::Array,
     "user",     // ValueKind::User
 };
-    
+
 const char* valueTypeAsString(ValueKind t)
 {
     const unsigned int i = static_cast<unsigned int>(t);


### PR DESCRIPTION
Hi,
I tried Ponder today with MinGW (mingw32-gcc (tdm-1) 5.1.0) which was the version supplied with the latest Code::Blocks IDE. Apparently, when using C++11 MinGW defines __STRICT_ANSI__ which causes strcmpcase to be missing, failing the build of util.cpp.
I have tried to fix this by explicitly checking for the combination of MinGW and C++11 and it seems to work for me at least, so I'd kindly ask you to review the fix.
Regards, Leo
