### PR TITLE
Fix std::logic_error not found error

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -27,6 +27,7 @@
  **
  ****************************************************************************/
 
+#include <stdexcept>
 #include <ponder/detail/util.hpp>
 
 #if defined(__GNUWIN32__) && __cplusplus >= 201103L


### PR DESCRIPTION
Compiler GCC version：gcc (GCC) 11.2.0
In this version compiler, cause std::logic_error type not found error, add <stdexcept> header file include to fix this compile error.